### PR TITLE
Make more specific filters much more reliable.

### DIFF
--- a/src/main/java/anticope/esixtwoone/ImageHUD.java
+++ b/src/main/java/anticope/esixtwoone/ImageHUD.java
@@ -59,7 +59,10 @@ public class ImageHUD extends HudElement {
         .name("tags")
         .description("Tags")
         .defaultValue("femboy")
-        .onChanged((v) -> empty = true)
+        .onChanged((v) -> {
+            source.reset();
+            empty = true;
+        })
         .build()
     );
 
@@ -67,7 +70,10 @@ public class ImageHUD extends HudElement {
         .name("size")
         .description("Size mode.")
         .defaultValue(Size.preview)
-        .onChanged((v) -> empty = true)
+        .onChanged((v) -> {
+            source.reset();
+            empty = true;
+        })
         .build()
     );
 
@@ -77,6 +83,7 @@ public class ImageHUD extends HudElement {
         .defaultValue(SourceType.e621)
         .onChanged((v) -> {
             source = Source.getSource(v);
+            source.reset();
             empty = true;
         })
         .build()

--- a/src/main/java/anticope/esixtwoone/sources/ESixTwoOne.java
+++ b/src/main/java/anticope/esixtwoone/sources/ESixTwoOne.java
@@ -7,16 +7,28 @@ import meteordevelopment.meteorclient.utils.network.Http;
 
 public class ESixTwoOne extends Source {
 
+    private int maxPage = 30;
+
+    @Override
+    public void reset() {
+        maxPage = 30;
+    }
+
     @Override
     public String randomImage(String filter, Size size) {
-        JsonObject result = Http.get("https://e621.net/posts.json?limit=10&tags="+filter+"&page="+ random.nextInt(1, 700)).sendJson(JsonObject.class);
+        int pageNum = random.nextInt(1, maxPage);
+        JsonObject result = Http.get("https://e621.net/posts.json?limit=320&tags="+filter+"&page="+ pageNum).sendJson(JsonObject.class);
         if (result.get("posts") instanceof JsonArray array) {
-            if (array.get(random.nextInt(0, 11)) instanceof JsonObject post) {
+            if(array.size() <= 0) {
+                maxPage = pageNum - 1;
+                return null;
+            }
+            if (array.get(random.nextInt(array.size())) instanceof JsonObject post) {
                 var url = post.get(size.toString()).getAsJsonObject().get("url").getAsString();
                 return url;
             }
         }
         return null;
     }
-    
+
 }

--- a/src/main/java/anticope/esixtwoone/sources/GelBooru.java
+++ b/src/main/java/anticope/esixtwoone/sources/GelBooru.java
@@ -17,6 +17,9 @@ public class GelBooru extends Source {
     }
 
     @Override
+    public void reset() {}
+
+    @Override
     public String randomImage(String filter, Size size) {
         String query = String.format("%s/index.php?page=dapi&s=post&q=index&tags=%s&pid=%d&json=1&limit=10", domain, filter, random.nextInt(0, lastPage));
         JsonElement result = Http.get(query).sendJson(JsonElement.class);
@@ -32,10 +35,10 @@ public class GelBooru extends Source {
                     var url = post.get(size.toString()+"_url").getAsString();
                     return url;
                 }
-            } 
+            }
         }
-        
+
         return null;
     }
-    
+
 }

--- a/src/main/java/anticope/esixtwoone/sources/Source.java
+++ b/src/main/java/anticope/esixtwoone/sources/Source.java
@@ -20,6 +20,8 @@ public abstract class Source {
 
     protected final Random random = new Random();
 
+    public abstract void reset();
+
     protected abstract String randomImage(String filter, Size size);
 
     public String getRandomImage(String filter, Size size) {


### PR DESCRIPTION
Modified the e621 random image function to fetch more possible images at once, and reduce max page if there's no results for that page (this allows up to 9600 unique images for filters that have that many results). The main purpose of this is to make it find images more reliable for tag combinations with relatively few results. Previously it would only find an image 50% of the time with a filter that only has 3500 images, now it may take a second or two to find the first image, but then would guarantee a result every time it tries after.